### PR TITLE
INT-1510: Change to work with latest electron

### DIFF
--- a/lib/resources/host.js
+++ b/lib/resources/host.js
@@ -1,7 +1,7 @@
 var BaseResource = require('./base');
 var _ = require('lodash');
 var os = (typeof window === 'undefined') ?
-  require('os') : window.require('remote').require('os');
+  require('os') : require('electron').remote.require('os');
 
 // var debug = require('debug')('mongodb-js-metrics:resources:app');
 

--- a/lib/trackers/intercom.js
+++ b/lib/trackers/intercom.js
@@ -7,7 +7,7 @@ var redact = require('mongodb-redact');
 var sentenceCase = require('../shared').sentenceCase;
 
 var os = (typeof window === 'undefined') ?
-  require('os') : window.require('remote').require('os');
+  require('os') : require('electron').remote.require('os');
 
 var IntercomTracker = State.extend({
   id: 'intercom',

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "type": "git",
     "url": "git://github.com/mongodb-js/metrics.git"
   },
+  "dependency-check": {
+    "ignore": [ "electron" ]
+  },
   "dependencies": {
     "ampersand-collection": "^1.5.0",
     "ampersand-collection-lodash-mixin": "^2.0.1",


### PR DESCRIPTION
`require('remote')` was removed in electron 1.x. Correct is `require('electron').remote` now.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb-js/metrics/5)
<!-- Reviewable:end -->
