### PR TITLE
update eslint-config version to most recent (2.2.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "xhr": "^2.2.0"
   },
   "devDependencies": {
-    "eslint-config-mongodb-js": "^1.0.5",
+    "eslint-config-mongodb-js": "^2.2.0",
     "mocha": "^2.3.3",
     "mongodb-js-fmt": "0.0.3",
     "mongodb-js-precommit": "^0.2.5",


### PR DESCRIPTION
Using the previous version of eslint-config (1.0.5) the precommit tests were failing because of deprecated rules. This update fixes that.