### PR TITLE
INT-1662 group bugsnag errors across OS, launch path, app version

### DIFF
--- a/lib/trackers/bugsnag.js
+++ b/lib/trackers/bugsnag.js
@@ -102,7 +102,7 @@ var BugsnagTracker = State.extend({
     payload.url = redact(payload.url);
     payload.name = redact(payload.name);
 
-    debug('sending report to bugnsnag', payload);
+    debug('sending report to bugsnag', payload);
     return true;
   },
   /**

--- a/lib/trackers/bugsnag.js
+++ b/lib/trackers/bugsnag.js
@@ -102,6 +102,11 @@ var BugsnagTracker = State.extend({
     payload.url = redact(payload.url);
     payload.name = redact(payload.name);
 
+    // group errors with same message in bugsnag dashboard
+    if (payload.metaData) {
+      payload.metaData.groupingHash = payload.message;
+    }
+
     debug('sending report to bugsnag', payload);
     return true;
   },


### PR DESCRIPTION
Currently, there are separate entries (and emails) on Bugsnag for the same error across different operating systems, launch paths, and Compass versions. Setting the groupingHash for a submission makes Bugsnag combine all received errors with the same groupingHash value, which reduces clutter. I chose to set the groupingHash as the error's message, but I can easily change it to something more or less specific if someone thinks that would be more useful. I also fixed a small typo in a debug call.

I have tested this on my computer by launching Compass from different directories and with different versions, and the grouping works, but I have not tested it on different operating systems.