### PR TITLE
Fix Intercom email can't be blank error

### DIFF
--- a/lib/resources/user.js
+++ b/lib/resources/user.js
@@ -10,7 +10,7 @@ module.exports = BaseResource.extend({
       required: true
     },
     name: 'string',
-    email: 'string',
+    email: {type: 'any', default: undefined, required: false, allowNull: true},
     twitter: 'string'
   },
   login: function(callback) {


### PR DESCRIPTION
The below started appearing when intercom messenger was upgraded
several weeks ago.  The root cause is user resource would send `email:‘’` which fails validation on Intercom's API server.  If we instead allow email to default to undefined, no empty string is sent to
intercom’s server and validation passes.  After this is merged, we’ll also need to change models/user.js in Compass.

```
Failed to load resource: the server responded with a status of 400 (Bad Request)
Uncaught (in promise {"type":"error.list","request_id":"anscsvqg0eamtn7i98t0","errors":[{"code":"parameter_invalid","message":"Email can't be blank"}]}
```