### PR TITLE
feat: make logging to users collection optional

### DIFF
--- a/lib/trackers/stitch.js
+++ b/lib/trackers/stitch.js
@@ -72,7 +72,7 @@ var StitchTracker = State.extend({
   },
   derived: {
     enabledAndConfigured: {
-      deps: ['enabled', 'appId', 'userId'],
+      deps: ['enabled', 'appId', 'userId', 'events', 'users'],
       fn: function() {
         return this.enabled && this.appId !== '' && this.userId !== '';
       }
@@ -110,9 +110,11 @@ var StitchTracker = State.extend({
     this._eventsDatabaseName = eventsNS.database;
     this._eventsCollectionName = eventsNS.collection;
 
-    var usersNS = parseNamespaceString(this.users);
-    this._usersDatabaseName = usersNS.database;
-    this._usersCollectionName = usersNS.collection;
+    if (this.users) {
+      var usersNS = parseNamespaceString(this.users);
+      this._usersDatabaseName = usersNS.database;
+      this._usersCollectionName = usersNS.collection;
+    }
 
     var self = this;
     return stitch.StitchClientFactory.create(this.appId)
@@ -164,6 +166,11 @@ var StitchTracker = State.extend({
 
     if (!this.hasBooted) {
       this.hasBooted = true;
+    }
+
+    // don't log user information if users namespace is not specified
+    if (!this.users) {
+      return;
     }
 
     return this._getCollection(

--- a/test/stitch.test.js
+++ b/test/stitch.test.js
@@ -16,8 +16,8 @@ describe('Stitch Tracker', function() {
     metrics.configure('stitch', {
       enabled: true,
       appId: 'compass-metrics-irinb',
-      eventNamespace: 'metrics.events',
-      userNamespace: 'metrics.users'
+      events: 'metrics.events',
+      users: 'metrics.users'
     });
 
     metrics.resources.reset();
@@ -117,6 +117,38 @@ describe('Stitch Tracker', function() {
       stitchTracker._enabledConfiguredChanged();
       return setupStub().then(function() {
         assert.ok(identifyStub.called);
+      });
+    });
+  });
+
+  describe('optional users collection', function() {
+    var _getCollectionStub;
+    var setupStub;
+
+    beforeEach(function() {
+      metrics.addResource(app);
+      metrics.addResource(user);
+      _getCollectionStub = sinon.stub(stitchTracker, '_getCollection');
+      setupStub = sinon.stub(stitchTracker, '_setup').returns(Promise.resolve({}));
+    });
+
+    afterEach(function() {
+      _getCollectionStub.restore();
+      setupStub.restore();
+    });
+
+    it('should only send to the users collection when this.users is specified', function() {
+      stitchTracker._enabledConfiguredChanged();
+      return setupStub().then(function() {
+        assert.ok(_getCollectionStub.called);
+      });
+    });
+
+    it('should not send to the users collection when this.users is falsey', function() {
+      stitchTracker.users = null;
+      stitchTracker._enabledConfiguredChanged();
+      return setupStub().then(function() {
+        assert.ok(!_getCollectionStub.called);
       });
     });
   });


### PR DESCRIPTION
This PR adds the ability to optionally *not* log to the users collection for the Stitch tracker. 

During configuration, if the `users` key is set to a falsey value (null, empty string), then no documents are sent to the users collection.

Example: 
```
    metrics.configure('stitch', {
      enabled: true,
      appId: 'compass-metrics-irinb',
      events: 'metrics.events',
      users: ''
    });
```
