### PR TITLE
chore: COMPASS-4132: Replace usage of `mongodb-stitch` w/ `mongodb-stitch-browser-sdk`|`mongodb-stitch-browser-sdk`

### DIFF
--- a/docs/stitch.md
+++ b/docs/stitch.md
@@ -15,7 +15,7 @@ The users schema is as shown in this example:
 ```json
 {
   "_id": "3c007a83-e8c3-4b52-9631-b5fd97950dce",
-  "last_login": {"$date": "2017-08-17T06:27:22.251Z"},
+  "last_login": { "$date": "2017-08-17T06:27:22.251Z" },
   "app_name": "My Cool App",
   "app_version": "2.0.1",
   "host_arch": "x64",
@@ -24,7 +24,7 @@ The users schema is as shown in this example:
   "host_total_memory_gb": 16,
   "host_free_memory_gb": 1.0611343383789062,
   "stitch_user_id": "5995374b05842951d8da03f6",
-  "created_at": {"$date":"2017-08-17T06:23:49.662Z"}
+  "created_at": { "$date": "2017-08-17T06:23:49.662Z" }
 }
 ```
 
@@ -40,19 +40,18 @@ Events are tracked in a separate collection `metrics.events`, and the documents 
   "resource": "App",
   "action": "launched",
   "user_id": "3c007a83-e8c3-4b52-9631-b5fd97950dce",
-  "created_at": {"$date":"2017-08-17T06:20:34.232Z"},
+  "created_at": { "$date": "2017-08-17T06:20:34.232Z" },
   "metadata": {
     "name": "My Cool App",
     "version": "2.0.1",
     "os_name": "macOS Sierra"
   },
-  "stitch_user_id":"599535b305842951d8da01fb"
+  "stitch_user_id": "599535b305842951d8da01fb"
 }
 ```
 
 The `user_id` field corresponds to the `_id` field in the users collection. Each event
 can have a metadata subdocument with information specific to the resource and action.
-
 
 ### Requirements
 
@@ -62,69 +61,80 @@ Before you can use the `stitch` tracker from this package, you need to create a 
 
 Once you're in your Stitch console, click on `mongodb-atlas` under _Atlas Clusters_. Under _Rules_, create 2 new collections, one for users and one for events tracking. The default namespaces are `metrics.users` and `metrics.events`, but you can use custom database and collection names as well.
 
-*Users Collection*
+_Users Collection_
 
 1. Click on your _users_ collection, and choose the _Filters_ tab. Remove any existing default filters.
 2. Now go to the _Field Rules_ tab. Select _Top-Level Document_. Ensure that all 3 boxes - Read, Write and Valid - are completely empty.
-2. Add a new field (_+ Add_ button) called `_id`. Configure the Read rule as below:
+3. Add a new field (_+ Add_ button) called `_id`. Configure the Read rule as below:
 
-    **Read**
-    ```json
-    {
-      "%%true": true
-    }
-    ```
-    **Write**
-    ```json
-    {
-      "%%true": true
-    }
-    ```
-    This rule ensures that the `_id` field can be read (so that updates succeed) and written to (on first creation of the document). Leave the Valid box empty.
-3. Click on _all other fields_, and enable the switch. Configure the Read and Write rules for _all other fields_ as below:
+   **Read**
 
-    **Read**
-    ```json
-    {
-      "%%true": false
-    }
-    ```
-    **Write**
-    ```json
-    {
-      "%%true": true
-    }
-    ```
-    These rules ensure that all other fields can never be read through the Stitch API, but can be written to.
+   ```json
+   {
+     "%%true": true
+   }
+   ```
 
+   **Write**
 
-*Events Collection*
+   ```json
+   {
+     "%%true": true
+   }
+   ```
+
+   This rule ensures that the `_id` field can be read (so that updates succeed) and written to (on first creation of the document). Leave the Valid box empty.
+
+4. Click on _all other fields_, and enable the switch. Configure the Read and Write rules for _all other fields_ as below:
+
+   **Read**
+
+   ```json
+   {
+     "%%true": false
+   }
+   ```
+
+   **Write**
+
+   ```json
+   {
+     "%%true": true
+   }
+   ```
+
+   These rules ensure that all other fields can never be read through the Stitch API, but can be written to.
+
+_Events Collection_
 
 1. Click on your _events_ collection, and choose the _Filters_ tab. Remove any existing default filters.
 2. Now go to the _Field Rules_ tab. Select _Top-Level Document_. Configure the Read rule as below:
 
-    **Read**
-    ```json
-    {
-      "%%true": false
-    }
-    ```
-    This ensures that no document of this collection can be read through the Stitch API. This collection is write-only. Leave the Write and Valid boxes empty.
+   **Read**
 
-2. Click on _all other fields_, and enable the switch. Configure the Write rule for _all other fields_ as below:
+   ```json
+   {
+     "%%true": false
+   }
+   ```
 
-    **Write**
-    ```json
-    {
-      "%%prev": {
-        "%exists": false
-      }
-    }
-    ```
-    This ensures that all other fields can only be created, but never updated. We don't allow changes to tracked events through the Stitch API.
+   This ensures that no document of this collection can be read through the Stitch API. This collection is write-only. Leave the Write and Valid boxes empty.
+
+3. Click on _all other fields_, and enable the switch. Configure the Write rule for _all other fields_ as below:
+
+   **Write**
+
+   ```json
+   {
+     "%%prev": {
+       "%exists": false
+     }
+   }
+   ```
+
+   This ensures that all other fields can only be created, but never updated. We don't allow changes to tracked events through the Stitch API.
 
 Your Stitch Application is now configured and ready for tracking metrics. All you need is the App ID (Click on _Clients_ in the sidebar to see it), and the namespaces of the users and events collections, if you chose non-default names.
-
 
 ### Tracker Configuration
 
@@ -134,10 +144,19 @@ The stitch tracker can be configured via `metrics.configure()`. Here is an examp
 // configure Stitch
 metrics.configure('stitch', {
   appId: 'my-app-metrics-vlgxs',
-  users: 'metrics-db.users-coll',     // optional, default is metrics.users
-  events: 'metrics-db.events-coll',   // optional, default is metrics.events
+  users: 'metrics-db.users-coll', // optional, default is metrics.users
+  events: 'metrics-db.events-coll', // optional, default is metrics.events
   enabled: true
 });
 ```
 
 A code example to configure a stitch tracker and send some metrics can be found in [`../examples/stitch.js`](../examples/stitch.js).
+
+### Closing Stitch Client
+
+The server side stitch SDK requires manually [closing stitch clients](https://www.npmjs.com/package/mongodb-stitch-server-sdk#closing-the-stitchappclient) like the node.js driver. A top-level helper function is available if manually closing the client is required:
+
+```js
+// close any open stitch clients
+metrics.close();
+```

--- a/lib/index.js
+++ b/lib/index.js
@@ -91,6 +91,12 @@ var Metrics = State.extend({
   info: function() {
     var args = Array.prototype.slice.call(arguments);
     this.track.apply(this, ['Error', 'info'].concat(args));
+  },
+  close: function() {
+    if (!trackers.has('stitch')) {
+      return;
+    }
+    trackers.get('stitch').close();
   }
 });
 

--- a/lib/trackers/stitch.js
+++ b/lib/trackers/stitch.js
@@ -18,6 +18,14 @@ var os =
     ? require('os')
     : require('electron').remote.require('os');
 
+var _stitchClient;
+function getStitchClient(appId) {
+  if (!_stitchClient) {
+    _stitchClient = stitch.Stitch.initializeDefaultAppClient(appId);
+  }
+  return _stitchClient;
+}
+
 var StitchTracker = State.extend({
   id: 'stitch',
   props: {
@@ -114,7 +122,11 @@ var StitchTracker = State.extend({
     }
   },
   _isTrackerReady: function() {
-    return this.enabledAndConfigured && this._client;
+    return (
+      this.enabledAndConfigured &&
+      this._client &&
+      this._client.auth.currentUser.id
+    );
   },
   _setup: function() {
     var eventsNS = parseNamespaceString(this.events);
@@ -128,24 +140,21 @@ var StitchTracker = State.extend({
     }
 
     var self = this;
-    return stitch.StitchClientFactory.create(this.appId).then(function(client) {
-      return client
-        .login()
-        .then(function() {
-          self._client = client;
-
-          debug('setup client', {
-            _client: self._client,
-            _eventsDatabaseName: self._eventsDatabaseName,
-            _eventsCollectionName: self._eventsCollectionName,
-            _usersDatabaseName: self._usersDatabaseName,
-            _usersCollectionName: self._usersCollectionName
-          });
-        })
-        .catch(function(e) {
-          debug('error logging in via stitch: %s', e.message);
+    self._client = getStitchClient(this.appId);
+    return self._client.auth
+      .loginWithCredential(new stitch.AnonymousCredential())
+      .then(function() {
+        debug('setup client', {
+          _client: self._client,
+          _eventsDatabaseName: self._eventsDatabaseName,
+          _eventsCollectionName: self._eventsCollectionName,
+          _usersDatabaseName: self._usersDatabaseName,
+          _usersCollectionName: self._usersCollectionName
         });
-    });
+      })
+      .catch(function(e) {
+        debug('error logging in via stitch: %s', e.message);
+      });
   },
   _identify: function() {
     // this is only used when a user is first created ($setOnInsert)
@@ -192,7 +201,7 @@ var StitchTracker = State.extend({
         if (err) {
           return debug('error sending identify to stitch: %s', err.message);
         }
-        updateObj.stitch_user_id = this._client.authedId();
+        updateObj.stitch_user_id = this._client.auth.currentUser.id;
         debug('sending identify', redact(updateObj));
         return collection.updateOne(
           { _id: this.userId },
@@ -206,13 +215,11 @@ var StitchTracker = State.extend({
     if (!this._isTrackerReady()) {
       return fn(new Error('stitch tracker not configured yet.'));
     }
-    return fn(
-      null,
-      this._client
-        .service('mongodb', 'mongodb-atlas')
-        .db(db)
-        .collection(name)
+    const mongoClient = this._client.getServiceClient(
+      stitch.RemoteMongoClient.factory,
+      'mongodb-atlas'
     );
+    return fn(null, mongoClient.db(db).collection(name));
   },
 
   /**
@@ -250,7 +257,7 @@ var StitchTracker = State.extend({
       if (err) {
         return debug('error sending event to stitch: %s', err.message);
       }
-      payload.stitch_user_id = this._client.authedId();
+      payload.stitch_user_id = this._client.auth.currentUser.id;
       debug('sending event `%s`', eventName, payload);
       return collection.insertOne(payload);
     }.bind(this);

--- a/lib/trackers/stitch.js
+++ b/lib/trackers/stitch.js
@@ -126,7 +126,7 @@ var StitchTracker = State.extend({
       this.enabledAndConfigured && this._client && this._client.auth.currentUser
     );
   },
-  _teardown: function() {
+  close: function() {
     if (!_stitchClient || !_stitchClient.close) return;
     _stitchClient.close();
   },

--- a/lib/trackers/stitch.js
+++ b/lib/trackers/stitch.js
@@ -1,6 +1,10 @@
 /* eslint no-console: 0 */
 
-var stitch = require('mongodb-stitch-browser-sdk');
+var stitch =
+  typeof window === 'undefined'
+    ? require('mongodb-stitch-server-sdk')
+    : require('mongodb-stitch-browser-sdk');
+
 var State = require('ampersand-state');
 var _ = require('lodash');
 var singleton = require('singleton-js');

--- a/lib/trackers/stitch.js
+++ b/lib/trackers/stitch.js
@@ -127,10 +127,8 @@ var StitchTracker = State.extend({
     );
   },
   _teardown: function() {
-    if (this._client) {
-      this._client.close();
-      _stitchClient = null;
-    }
+    if (!_stitchClient || !_stitchClient.close) return;
+    _stitchClient.close();
   },
   _setup: function() {
     var eventsNS = parseNamespaceString(this.events);
@@ -144,7 +142,9 @@ var StitchTracker = State.extend({
     }
 
     var self = this;
-    self._client = getStitchClient(this.appId);
+    if (!self._client) {
+      self._client = getStitchClient(this.appId);
+    }
     return self._client.auth
       .loginWithCredential(new stitch.AnonymousCredential())
       .then(function() {

--- a/lib/trackers/stitch.js
+++ b/lib/trackers/stitch.js
@@ -123,9 +123,7 @@ var StitchTracker = State.extend({
   },
   _isTrackerReady: function() {
     return (
-      this.enabledAndConfigured &&
-      this._client &&
-      this._client.auth.currentUser.id
+      this.enabledAndConfigured && this._client && this._client.auth.currentUser
     );
   },
   _setup: function() {

--- a/lib/trackers/stitch.js
+++ b/lib/trackers/stitch.js
@@ -1,6 +1,6 @@
 /* eslint no-console: 0 */
 
-var stitch = require('mongodb-stitch');
+var stitch = require('mongodb-stitch-browser-sdk');
 var State = require('ampersand-state');
 var _ = require('lodash');
 var singleton = require('singleton-js');

--- a/lib/trackers/stitch.js
+++ b/lib/trackers/stitch.js
@@ -21,7 +21,7 @@ var os =
 var _stitchClient;
 function getStitchClient(appId) {
   if (!_stitchClient) {
-    _stitchClient = stitch.Stitch.initializeDefaultAppClient(appId);
+    _stitchClient = stitch.Stitch.initializeAppClient(appId);
   }
   return _stitchClient;
 }
@@ -125,6 +125,12 @@ var StitchTracker = State.extend({
     return (
       this.enabledAndConfigured && this._client && this._client.auth.currentUser
     );
+  },
+  _teardown: function() {
+    if (this._client) {
+      this._client.close();
+      _stitchClient = null;
+    }
   },
   _setup: function() {
     var eventsNS = parseNamespaceString(this.events);

--- a/package-lock.json
+++ b/package-lock.json
@@ -382,6 +382,12 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true
+    },
     "array-includes": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.1.tgz",
@@ -536,6 +542,12 @@
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
     "bugsnag-js": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/bugsnag-js/-/bugsnag-js-3.3.3.tgz",
@@ -560,6 +572,24 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
+    },
+    "camelcase-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+      "dev": true,
+      "requires": {
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+          "dev": true
+        }
+      }
     },
     "caseless": {
       "version": "0.12.0",
@@ -653,6 +683,12 @@
         }
       }
     },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -688,6 +724,56 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -703,6 +789,15 @@
         "semver": "^5.5.0",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
+      }
+    },
+    "currently-unhandled": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "dev": true,
+      "requires": {
+        "array-find-index": "^1.0.1"
       }
     },
     "dashdash": {
@@ -725,6 +820,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true
     },
     "deep-is": {
@@ -937,6 +1038,279 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "electron": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-6.1.7.tgz",
+      "integrity": "sha512-QhBA/fcYJit2XJGkD2xEfxlWTtTaWYu7qkKVohtVWXpELFqkpel2DCDxet5BTo0qs8ukuZHxlQPnIonODnl2bw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "^10.12.18",
+        "electron-download": "^4.1.0",
+        "extract-zip": "^1.0.3"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.17.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.14.tgz",
+          "integrity": "sha512-G0UmX5uKEmW+ZAhmZ6PLTQ5eu/VPaT+d/tdLd5IFsKRPcbe6lPxocBtcYBFSaLaCW8O60AX90e91Nsp8lVHCNw==",
+          "dev": true
+        }
+      }
+    },
+    "electron-download": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/electron-download/-/electron-download-4.1.1.tgz",
+      "integrity": "sha512-FjEWG9Jb/ppK/2zToP+U5dds114fM1ZOJqMAR4aXXL5CvyPE9fiqBK/9YcwC9poIFQTEJk/EM/zyRwziziRZrg==",
+      "dev": true,
+      "requires": {
+        "debug": "^3.0.0",
+        "env-paths": "^1.0.0",
+        "fs-extra": "^4.0.1",
+        "minimist": "^1.2.0",
+        "nugget": "^2.0.1",
+        "path-exists": "^3.0.0",
+        "rc": "^1.2.1",
+        "semver": "^5.4.1",
+        "sumchecker": "^2.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "fs-extra": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "electron-mocha": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/electron-mocha/-/electron-mocha-8.2.0.tgz",
+      "integrity": "sha512-Jp+GUHBVyWZHILPaDYplnWtglCsTFrMSG9Ls5kE9kmnHzAaCQtWtyLn/5PHYfVMxwGpEPZrBV4QUDPNgcbiPTQ==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^4.1.1",
+        "electron-window": "^0.8.0",
+        "fs-extra": "^8.1.0",
+        "log-symbols": "^3.0.0",
+        "mocha": "^7.0.0",
+        "which": "^2.0.2",
+        "yargs": "^15.1.0"
+      },
+      "dependencies": {
+        "ansi-colors": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+          "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "cliui": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "log-symbols": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+          "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.2"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "yargs": {
+          "version": "15.1.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.1.0.tgz",
+          "integrity": "sha512-T39FNN1b6hCW4SOIk1XyTOWxtXdcen0t+XYrysQmChzSipvhBO8Bj0nK1ozAasdk24dNWuMZvr4k24nz+8HHLg==",
+          "dev": true,
+          "requires": {
+            "cliui": "^6.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^4.1.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^4.2.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^16.1.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "16.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-16.1.0.tgz",
+          "integrity": "sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
+    "electron-window": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/electron-window/-/electron-window-0.8.1.tgz",
+      "integrity": "sha1-FsoYfrSHCwZ5J0/IKZxZYOarLF4=",
+      "dev": true,
+      "requires": {
+        "is-electron-renderer": "^2.0.0"
+      }
+    },
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
@@ -949,6 +1323,21 @@
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "requires": {
         "once": "^1.4.0"
+      }
+    },
+    "env-paths": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-1.0.0.tgz",
+      "integrity": "sha1-QWgTO0K7BcOKNbGuQ5fIKYqzaeA=",
+      "dev": true
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
       }
     },
     "es-abstract": {
@@ -1233,6 +1622,35 @@
         "tmp": "^0.0.33"
       }
     },
+    "extract-zip": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
+      "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+      "dev": true,
+      "requires": {
+        "concat-stream": "1.6.2",
+        "debug": "2.6.9",
+        "mkdirp": "0.5.1",
+        "yauzl": "2.4.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -1274,6 +1692,15 @@
       "dev": true,
       "requires": {
         "reusify": "^1.0.0"
+      }
+    },
+    "fd-slicer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "dev": true,
+      "requires": {
+        "pend": "~1.2.0"
       }
     },
     "figures": {
@@ -1403,6 +1830,12 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
+    },
+    "get-stdin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
       "dev": true
     },
     "get-stream": {
@@ -1604,6 +2037,15 @@
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
+    "indent-string": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+      "dev": true,
+      "requires": {
+        "repeating": "^2.0.0"
+      }
+    },
     "indexes-of": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
@@ -1624,6 +2066,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "dev": true
     },
     "inquirer": {
       "version": "6.5.2",
@@ -1698,6 +2146,12 @@
         }
       }
     },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
     "is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -1725,10 +2179,22 @@
       "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
       "dev": true
     },
+    "is-electron-renderer": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-electron-renderer/-/is-electron-renderer-2.0.1.tgz",
+      "integrity": "sha1-pGnQVvl1aXxYyYxgI+sKp5r4laI=",
+      "dev": true
+    },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
+    "is-finite": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
       "dev": true
     },
     "is-fullwidth-code-point": {
@@ -1819,6 +2285,12 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
       "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "dev": true
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
       "dev": true
     },
     "isarray": {
@@ -1976,6 +2448,19 @@
         "type-check": "~0.3.2"
       }
     },
+    "load-json-file": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
+      }
+    },
     "locate-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -2082,10 +2567,52 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
+    "loud-rejection": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+      "dev": true,
+      "requires": {
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
+      }
+    },
     "macos-release": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.3.0.tgz",
       "integrity": "sha512-OHhSbtcviqMPt7yfw5ef5aghS2jzFVKEFyCJndQt2YpSQ9qRVSEv2axSJI1paVThEu+FFGs584h/1YhxjVqajA=="
+    },
+    "map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+      "dev": true
+    },
+    "meow": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+      "dev": true,
+      "requires": {
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
     },
     "merge2": {
       "version": "1.3.0",
@@ -2545,6 +3072,50 @@
         "path-key": "^2.0.0"
       }
     },
+    "nugget": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/nugget/-/nugget-2.0.1.tgz",
+      "integrity": "sha1-IBCVpIfhrTYIGzQy+jytpPjQcbA=",
+      "dev": true,
+      "requires": {
+        "debug": "^2.1.3",
+        "minimist": "^1.1.0",
+        "pretty-bytes": "^1.0.2",
+        "progress-stream": "^1.1.0",
+        "request": "^2.45.0",
+        "single-line-log": "^1.1.2",
+        "throttleit": "0.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
@@ -2723,6 +3294,15 @@
       "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.3.tgz",
       "integrity": "sha512-QhhZ+DCCit2Coi2vmAKbq5RGTRcQUOE2+REgv8vdyu7MnYx2eZztegqtTx99TZ86GTIwqiy3+4nQTWZ2tgmdCA=="
     },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
+      "requires": {
+        "error-ex": "^1.2.0"
+      }
+    },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -2767,6 +3347,12 @@
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true
     },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+      "dev": true
+    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -2777,6 +3363,27 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
       "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==",
       "dev": true
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
     },
     "pkg-up": {
       "version": "3.1.0",
@@ -2862,16 +3469,81 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
+    "pretty-bytes": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
+      "integrity": "sha1-CiLoIQYJrTVUL4yNXSFZr/B1HIQ=",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^4.0.1",
+        "meow": "^3.1.0"
+      }
+    },
     "process": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
       "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
     },
     "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
+    },
+    "progress-stream": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/progress-stream/-/progress-stream-1.2.0.tgz",
+      "integrity": "sha1-LNPP6jO6OonJwSHsM0er6asSX3c=",
+      "dev": true,
+      "requires": {
+        "speedometer": "~0.1.2",
+        "through2": "~0.2.3"
+      },
+      "dependencies": {
+        "object-keys": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+          "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "through2": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.2.3.tgz",
+          "integrity": "sha1-6zKE2k6jEbbMis42U3SKUqvyWj8=",
+          "dev": true,
+          "requires": {
+            "readable-stream": "~1.1.9",
+            "xtend": "~2.1.1"
+          }
+        },
+        "xtend": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+          "dev": true,
+          "requires": {
+            "object-keys": "~0.4.0"
+          }
+        }
+      }
     },
     "prop-types": {
       "version": "15.7.2",
@@ -2913,6 +3585,26 @@
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
       "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
     },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
     "react-is": {
       "version": "16.12.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
@@ -2930,6 +3622,61 @@
         "json-parse-better-errors": "^1.0.1",
         "normalize-package-data": "^2.0.0",
         "npm-normalize-package-bin": "^1.0.0"
+      }
+    },
+    "read-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
+      },
+      "dependencies": {
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        }
+      }
+    },
+    "read-pkg-up": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "dev": true,
+      "requires": {
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
+          "requires": {
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "^2.0.0"
+          }
+        }
       }
     },
     "readable-stream": {
@@ -2952,11 +3699,30 @@
         "picomatch": "^2.0.4"
       }
     },
+    "redent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+      "dev": true,
+      "requires": {
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
+      }
+    },
     "regexpp": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
       "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
       "dev": true
+    },
+    "repeating": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "dev": true,
+      "requires": {
+        "is-finite": "^1.0.0"
+      }
     },
     "request": {
       "version": "2.88.0",
@@ -3117,6 +3883,52 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
+    "single-line-log": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/single-line-log/-/single-line-log-1.1.2.tgz",
+      "integrity": "sha1-wvg/Jzo+GhbtsJlWYdoO1e8DM2Q=",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
+    },
     "singleton-js": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/singleton-js/-/singleton-js-1.0.0.tgz",
@@ -3223,6 +4035,12 @@
       "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
       "dev": true
     },
+    "speedometer": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-0.1.4.tgz",
+      "integrity": "sha1-mHbb0qFp0xFUAtSObqYynIgWpQ0=",
+      "dev": true
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -3294,16 +4112,60 @@
         "ansi-regex": "^3.0.0"
       }
     },
+    "strip-bom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "dev": true,
+      "requires": {
+        "is-utf8": "^0.2.0"
+      }
+    },
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+    },
+    "strip-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^4.0.1"
+      }
     },
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
+    },
+    "sumchecker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-2.0.2.tgz",
+      "integrity": "sha1-D0LBDl0F2l1C7qPlbDOZo31sWz4=",
+      "dev": true,
+      "requires": {
+        "debug": "^2.2.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
     },
     "supports-color": {
       "version": "5.5.0",
@@ -3366,6 +4228,12 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
+    "throttleit": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
+      "integrity": "sha1-z+34jmDADdlpe2H90qg0OptoDq8=",
+      "dev": true
+    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -3421,6 +4289,12 @@
         }
       }
     },
+    "trim-newlines": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+      "dev": true
+    },
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
@@ -3462,6 +4336,12 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
     "typescript": {
@@ -3528,6 +4408,12 @@
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "uuid": {
       "version": "3.4.0",
@@ -3665,6 +4551,33 @@
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
+    "xvfb-maybe": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/xvfb-maybe/-/xvfb-maybe-0.2.1.tgz",
+      "integrity": "sha1-7YyxMpV7eEi0OZhMZvAQ6n8kNhs=",
+      "dev": true,
+      "requires": {
+        "debug": "^2.2.0",
+        "which": "^1.2.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
     "y18n": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
@@ -3736,6 +4649,15 @@
         "flat": "^4.1.0",
         "lodash": "^4.17.15",
         "yargs": "^13.3.0"
+      }
+    },
+    "yauzl": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+      "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+      "dev": true,
+      "requires": {
+        "fd-slicer": "~1.0.1"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -230,11 +230,6 @@
         }
       }
     },
-    "Base64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/Base64/-/Base64-1.1.0.tgz",
-      "integrity": "sha512-qeacf8dvGpf+XAT27ESHMh7z84uRzj/ua2pQdJg483m3bEXv/kVFtDnMgvf70BQGqzbZhR9t6BmASzKvqfJf3Q=="
-    },
     "acorn": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
@@ -474,6 +469,11 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -513,10 +513,19 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
-    "bson": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-2.0.8.tgz",
-      "integrity": "sha512-0F0T3gHeOwJzHWcN60BZomqj5hCBDRk4b3fANuruvDTnyJJ8sggABKSaePM2F34THNZZSIlB2P1mk2nQWgBr9w=="
+    "buffer": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
+      "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      }
+    },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "bugsnag-js": {
       "version": "3.3.3",
@@ -760,11 +769,6 @@
         }
       }
     },
-    "detect-browser": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-1.12.0.tgz",
-      "integrity": "sha1-cbV9eAn8bkIFCyj4lSkSPBsykPk="
-    },
     "detective": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/detective/-/detective-5.2.0.tgz",
@@ -916,19 +920,19 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true
-    },
-    "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "requires": {
-        "iconv-lite": "~0.4.13"
-      }
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -1255,15 +1259,6 @@
         "reusify": "^1.0.0"
       }
     },
-    "fetch-everywhere": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/fetch-everywhere/-/fetch-everywhere-1.0.5.tgz",
-      "integrity": "sha1-skl/R6V9kCazkHwJdWrPX0vTTos=",
-      "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
-      }
-    },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -1552,9 +1547,15 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "ignore": {
       "version": "4.0.6",
@@ -1864,6 +1865,23 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
+    "jsonwebtoken": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.2.1.tgz",
+      "integrity": "sha512-l8rUBr0fqYYwPc8/ZGrue7GiW7vWdZtZqelxo4Sd5lMvuEeCK8/wS54sEo6tJhdZ6hqfutsj6COgC0d1XdbHGw==",
+      "requires": {
+        "jws": "^3.1.4",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "xtend": "^4.0.1"
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -1891,10 +1909,24 @@
       "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
       "dev": true
     },
-    "jwt-decode": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-2.2.0.tgz",
-      "integrity": "sha1-fYa9VmefWM5qhHBKZX3TkruoGnk="
+    "jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "requires": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "key-tree-store": {
       "version": "1.3.0",
@@ -1944,6 +1976,41 @@
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+    },
     "lodash.uniq": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
@@ -1967,6 +2034,11 @@
       "requires": {
         "@sinonjs/commons": "^1.7.0"
       }
+    },
+    "long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -2131,14 +2203,6 @@
         "node-source-walk": "^4.0.0"
       }
     },
-    "mongodb-extjson": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/mongodb-extjson/-/mongodb-extjson-2.1.4.tgz",
-      "integrity": "sha512-AYGhTnrMoPW3JXdtY2QkP3kPBNrUqcTW4tQaW1rQ/JO41QCiMqIq5RWf5e3lhs4McGx9rIXHKPYGDH6TDp8RHg==",
-      "requires": {
-        "bson": "^2.0.7"
-      }
-    },
     "mongodb-js-precommit": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/mongodb-js-precommit/-/mongodb-js-precommit-2.2.0.tgz",
@@ -2240,17 +2304,90 @@
         "lodash": "^4.17.15"
       }
     },
-    "mongodb-stitch": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/mongodb-stitch/-/mongodb-stitch-3.0.6.tgz",
-      "integrity": "sha512-X1BuyXTTZ///rsKqW08RoxtwEExcWH4E68E/Zruld2e9XIT5u+IFkfcZdq4HXx0+SgP4i54UzvyTVtX7EylJvg==",
+    "mongodb-stitch-browser-core": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/mongodb-stitch-browser-core/-/mongodb-stitch-browser-core-4.8.0.tgz",
+      "integrity": "sha512-tKzNW+w6VFQOS+opbC8lPjmgJx8H+/4s8qIwM2fcH+GUti+J6hcj3b8Eei7VcyHiWYNsS8S0cx+BypOmILhfeg==",
       "requires": {
-        "Base64": "^1.0.1",
-        "detect-browser": "^1.7.0",
-        "fetch-everywhere": "^1.0.5",
-        "jwt-decode": "^2.2.0",
-        "mongodb-extjson": "^2.1.0",
-        "query-string": "^4.3.4"
+        "bson": "4.0.2",
+        "detect-browser": "^3.0.0",
+        "mongodb-stitch-core-sdk": "^4.8.0",
+        "whatwg-fetch": "^3.0.0"
+      },
+      "dependencies": {
+        "bson": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-4.0.2.tgz",
+          "integrity": "sha512-rBdCxMBCg2aR420e1oKUejjcuPZLTibA7zEhWAlliFWEwzuBCC9Dkp5r7VFFIQB2t1WVsvTbohry575mc7Xw5A==",
+          "requires": {
+            "buffer": "^5.1.0",
+            "long": "^4.0.0"
+          }
+        },
+        "detect-browser": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-3.0.1.tgz",
+          "integrity": "sha512-L6b76EfUxnoxGHM5Vz7nrshQPIbOHtitDWpGufrp5srQdJrEYi1xpUVZeFbfssWAJvUWo/iDIVlz8hOP4Z8OCw=="
+        }
+      }
+    },
+    "mongodb-stitch-browser-sdk": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/mongodb-stitch-browser-sdk/-/mongodb-stitch-browser-sdk-4.8.0.tgz",
+      "integrity": "sha512-+u5OOwxhGFee2JiS/ocVqR4OQw5wEKCH99w0CJz9l5NqNpQeR1VZRt9HmMLk7k9fn4/LaL5QcdalzA9YA+T8eA==",
+      "requires": {
+        "mongodb-stitch-browser-core": "^4.8.0",
+        "mongodb-stitch-browser-services-mongodb-remote": "^4.8.0"
+      }
+    },
+    "mongodb-stitch-browser-services-mongodb-remote": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/mongodb-stitch-browser-services-mongodb-remote/-/mongodb-stitch-browser-services-mongodb-remote-4.8.0.tgz",
+      "integrity": "sha512-LPtuOufHKzrATNJB+DAdK0LYRvoVaAI+3Oobqx9FI9WAjNY22lwHiJQ7FBFejSEz1YL7Nap6f7Z2P2DlYr0WsA==",
+      "requires": {
+        "mongodb-stitch-browser-core": "^4.8.0",
+        "mongodb-stitch-core-services-mongodb-remote": "^4.8.0"
+      }
+    },
+    "mongodb-stitch-core-sdk": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/mongodb-stitch-core-sdk/-/mongodb-stitch-core-sdk-4.8.0.tgz",
+      "integrity": "sha512-IK6Yh8mGsX7zzgbk6l/4xt8lxYORpEc/rWSaZoNo70h+u0gBcNlOes6TdlqYgzi5Q/mT0gqWI9jhInrg0IvnGQ==",
+      "requires": {
+        "base64-js": "^1.3.0",
+        "bson": "4.0.2",
+        "jsonwebtoken": "8.2.1"
+      },
+      "dependencies": {
+        "bson": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-4.0.2.tgz",
+          "integrity": "sha512-rBdCxMBCg2aR420e1oKUejjcuPZLTibA7zEhWAlliFWEwzuBCC9Dkp5r7VFFIQB2t1WVsvTbohry575mc7Xw5A==",
+          "requires": {
+            "buffer": "^5.1.0",
+            "long": "^4.0.0"
+          }
+        }
+      }
+    },
+    "mongodb-stitch-core-services-mongodb-remote": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/mongodb-stitch-core-services-mongodb-remote/-/mongodb-stitch-core-services-mongodb-remote-4.8.0.tgz",
+      "integrity": "sha512-sxhmUqXlcn5152vqyoN7tQnowNKMSHUVms0rXOWXMVoHGf5eK+kqhtuT4haz/daa0pwR9L50NKYBRxOLt3phRg==",
+      "requires": {
+        "bson": "4.0.2",
+        "mongodb-stitch-core-sdk": "^4.8.0"
+      },
+      "dependencies": {
+        "bson": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-4.0.2.tgz",
+          "integrity": "sha512-rBdCxMBCg2aR420e1oKUejjcuPZLTibA7zEhWAlliFWEwzuBCC9Dkp5r7VFFIQB2t1WVsvTbohry575mc7Xw5A==",
+          "requires": {
+            "buffer": "^5.1.0",
+            "long": "^4.0.0"
+          }
+        }
       }
     },
     "ms": {
@@ -2297,15 +2434,6 @@
       "requires": {
         "object.getownpropertydescriptors": "^2.0.3",
         "semver": "^5.7.0"
-      }
-    },
-    "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
       }
     },
     "node-source-walk": {
@@ -2357,7 +2485,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object-inspect": {
       "version": "1.7.0",
@@ -2703,15 +2832,6 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
-    "query-string": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
-      "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
-      "requires": {
-        "object-assign": "^4.1.0",
-        "strict-uri-encode": "^1.0.0"
-      }
-    },
     "react-is": {
       "version": "16.12.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
@@ -3043,11 +3163,6 @@
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
-    },
-    "strict-uri-encode": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
     "string-width": {
       "version": "2.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -513,6 +513,15 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
+    "bson": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.0.2.tgz",
+      "integrity": "sha512-rBdCxMBCg2aR420e1oKUejjcuPZLTibA7zEhWAlliFWEwzuBCC9Dkp5r7VFFIQB2t1WVsvTbohry575mc7Xw5A==",
+      "requires": {
+        "buffer": "^5.1.0",
+        "long": "^4.0.0"
+      }
+    },
     "buffer": {
       "version": "5.4.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
@@ -1186,6 +1195,14 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "eventsource": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.0.7.tgz",
+      "integrity": "sha512-4Ln17+vVT0k8aWq+t/bF5arcS3EpT9gYtW66EPacdj/mAFevznsnyoHLPy2BA8gbIQeIHoPsvwmfBftfcG//BQ==",
+      "requires": {
+        "original": "^1.0.0"
+      }
+    },
     "execa": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
@@ -1337,6 +1354,16 @@
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
+    "fs-extra": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
+      "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1476,9 +1503,7 @@
     "graceful-fs": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
-      "dev": true,
-      "optional": true
+      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
     },
     "growl": {
       "version": "1.10.5",
@@ -1864,6 +1889,14 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
     },
     "jsonwebtoken": {
       "version": "8.2.1",
@@ -2390,6 +2423,36 @@
         }
       }
     },
+    "mongodb-stitch-server-core": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/mongodb-stitch-server-core/-/mongodb-stitch-server-core-4.8.0.tgz",
+      "integrity": "sha512-yRC32L6+QrOVYMbrNPN1EVA15SX5SIhBuAqbQymRUfFJdg2ZHviYtovZq39P0t9oOvIyNzA3oYBMT+PVUEZcSw==",
+      "requires": {
+        "bson": "4.0.2",
+        "eventsource": "1.0.7",
+        "fs-extra": "^6.0.1",
+        "mongodb-stitch-core-sdk": "^4.8.0",
+        "node-fetch": "^2.3.0"
+      }
+    },
+    "mongodb-stitch-server-sdk": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/mongodb-stitch-server-sdk/-/mongodb-stitch-server-sdk-4.8.0.tgz",
+      "integrity": "sha512-nuxYmvuTo7LtIKutciqflcctlTkGRFRUPv8Wvup2FOF9GFxaYUDxWryyiqdKt3OdyFgVnFTyXscxOF6SmzG91Q==",
+      "requires": {
+        "mongodb-stitch-server-core": "^4.8.0",
+        "mongodb-stitch-server-services-mongodb-remote": "^4.8.0"
+      }
+    },
+    "mongodb-stitch-server-services-mongodb-remote": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/mongodb-stitch-server-services-mongodb-remote/-/mongodb-stitch-server-services-mongodb-remote-4.8.0.tgz",
+      "integrity": "sha512-15YVkcYrwx1QpPMMMto3BVXMm6jtK5eqRk9FlfbqADANqMNLhUbUK7wJjYjz2BRtmYxgFThSiOb98vuU4Zryrw==",
+      "requires": {
+        "mongodb-stitch-core-services-mongodb-remote": "^4.8.0",
+        "mongodb-stitch-server-core": "^4.8.0"
+      }
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -2435,6 +2498,11 @@
         "object.getownpropertydescriptors": "^2.0.3",
         "semver": "^5.7.0"
       }
+    },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "node-source-walk": {
       "version": "4.2.0",
@@ -2587,6 +2655,14 @@
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2",
         "word-wrap": "~1.2.3"
+      }
+    },
+    "original": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
+      "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
+      "requires": {
+        "url-parse": "^1.4.3"
       }
     },
     "os-name": {
@@ -2832,6 +2908,11 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
+    "querystringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
+      "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
+    },
     "react-is": {
       "version": "16.12.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
@@ -2927,6 +3008,11 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resolve": {
       "version": "1.14.2",
@@ -3421,12 +3507,26 @@
         }
       }
     },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+    },
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "requires": {
         "punycode": "^2.1.0"
+      }
+    },
+    "url-parse": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
+      "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
+      "requires": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "uuid": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "mongodb-ns": "^2.0.0",
     "mongodb-redact": "0.2.0",
     "mongodb-stitch-browser-sdk": "^4.8.0",
+    "mongodb-stitch-server-sdk": "^4.8.0",
     "os-name": "^3.1.0",
     "request": "^2.67.0",
     "singleton-js": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "check": "mongodb-js-precommit",
     "test": "mocha",
-    "ci": "npm run check && npm test"
+    "test:electron": "xvfb-maybe electron-mocha --renderer",
+    "ci": "npm run check && npm test && npm run test:electron"
   },
   "homepage": "http://github.com/mongodb-js/metrics",
   "repository": {
@@ -38,10 +39,13 @@
     "xhr": "^2.2.0"
   },
   "devDependencies": {
+    "electron": "^6.1.7",
+    "electron-mocha": "^8.2.0",
     "eslint-config-mongodb-js": "^5.0.3",
     "mocha": "^7.0.0",
     "mongodb-js-precommit": "^2.1.0",
-    "sinon": "^8.1.1"
+    "sinon": "^8.1.1",
+    "xvfb-maybe": "^0.2.1"
   },
   "license": "Apache-2.0"
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lodash": "^4.13.1",
     "mongodb-ns": "^2.0.0",
     "mongodb-redact": "0.2.0",
-    "mongodb-stitch": "^3.0.6",
+    "mongodb-stitch-browser-sdk": "^4.8.0",
     "os-name": "^3.1.0",
     "request": "^2.67.0",
     "singleton-js": "^1.0.0",

--- a/test/stitch.test.js
+++ b/test/stitch.test.js
@@ -38,6 +38,7 @@ describe('Stitch Tracker', function() {
 
   afterEach(function() {
     stitchTracker.clear();
+    stitchTracker._teardown();
   });
 
   it('correctly sets enabledAndConfigured when props change', function() {
@@ -157,9 +158,5 @@ describe('Stitch Tracker', function() {
         assert.ok(!_getCollectionStub.called);
       });
     });
-  });
-
-  after(function() {
-    stitchTracker._client.close();
   });
 });

--- a/test/stitch.test.js
+++ b/test/stitch.test.js
@@ -73,10 +73,12 @@ describe('Stitch Tracker', function() {
   describe('trackFromQueue', function() {
     it('should call fn with provided arguments from the queue', function() {
       var fnSpy = sinon.spy();
-      stitchTracker._callsQueue = [{
-        fn: fnSpy,
-        args: ['mongod', 'user']
-      }];
+      stitchTracker._callsQueue = [
+        {
+          fn: fnSpy,
+          args: ['mongod', 'user']
+        }
+      ];
       stitchTracker._trackFromQueue();
       assert.ok(fnSpy.calledWith('mongod', 'user'));
     });
@@ -92,7 +94,9 @@ describe('Stitch Tracker', function() {
       metrics.addResource(user);
       trackFromQueueStub = sinon.stub(stitchTracker, '_trackFromQueue');
       identifyStub = sinon.stub(stitchTracker, '_identify');
-      setupStub = sinon.stub(stitchTracker, '_setup').returns(Promise.resolve({}));
+      setupStub = sinon
+        .stub(stitchTracker, '_setup')
+        .returns(Promise.resolve({}));
     });
 
     afterEach(function() {
@@ -129,7 +133,9 @@ describe('Stitch Tracker', function() {
       metrics.addResource(app);
       metrics.addResource(user);
       _getCollectionStub = sinon.stub(stitchTracker, '_getCollection');
-      setupStub = sinon.stub(stitchTracker, '_setup').returns(Promise.resolve({}));
+      setupStub = sinon
+        .stub(stitchTracker, '_setup')
+        .returns(Promise.resolve({}));
     });
 
     afterEach(function() {
@@ -151,5 +157,9 @@ describe('Stitch Tracker', function() {
         assert.ok(!_getCollectionStub.called);
       });
     });
+  });
+
+  after(function() {
+    stitchTracker._client.close();
   });
 });

--- a/test/stitch.test.js
+++ b/test/stitch.test.js
@@ -38,7 +38,7 @@ describe('Stitch Tracker', function() {
 
   afterEach(function(done) {
     stitchTracker.clear();
-    stitchTracker._teardown();
+    stitchTracker.close();
     done();
   });
 

--- a/test/stitch.test.js
+++ b/test/stitch.test.js
@@ -36,16 +36,18 @@ describe('Stitch Tracker', function() {
     stitchTracker = metrics.trackers.get('stitch');
   });
 
-  afterEach(function() {
+  afterEach(function(done) {
     stitchTracker.clear();
     stitchTracker._teardown();
+    done();
   });
 
-  it('correctly sets enabledAndConfigured when props change', function() {
+  it('correctly sets enabledAndConfigured when props change', function(done) {
     stitchTracker.enabled = false;
     assert.ok(!stitchTracker.enabledAndConfigured);
     stitchTracker.enabled = true;
     assert.ok(stitchTracker.enabledAndConfigured);
+    done();
   });
 
   it('should only initialize after setting app and user resources', function(done) {


### PR DESCRIPTION
Replaces the usage of `mongodb-stitch` w/ `mongodb-stitch-browser-sdk`|`mongodb-stitch-browser-sdk` for the Stitch tracker. 

For now, we just do a conditional `require()` for server or browser like we already do for electron.

The server side stitch SDK requires manually [closing stitch clients](https://www.npmjs.com/package/mongodb-stitch-server-sdk#closing-the-stitchappclient) like the node.js driver. A top-level helper function is available if manually closing the client is required:

```js
// close any open stitch clients
metrics.close();
```

I've also updated travis to test in an electron renderer process as well.